### PR TITLE
Replace warning about viewing materials making you ineligible to participate in DART

### DIFF
--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -44,7 +44,7 @@ Additionally, beyond the NIH grant, we have other articles and miscellany we sug
 
 ## Pivoting to data science
 
-Pivoting to a data science methodology, one that prioritizes writing code and using version control, can be challenging!  We invite you to consider an overview of why this approach is helpful in our NIH R25 training module called [Reproducibility](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md).  This can help give you additional motivation when you're struggling with common challenges like:
+Pivoting to a data science methodology, one that prioritizes writing code and using version control, can be challenging!  We invite you to consider an overview of why this approach is helpful in our [Reproducibility training module](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md).  This can help give you additional motivation when you're struggling with common challenges like:
 
 - Typing computer commands when you're used to point and click
 - Programming when you're used to spreadsheet data analysis
@@ -63,11 +63,11 @@ Literate statistical programming resources you might find useful include:
 
 If you aren't used to working with raw data that hasn't been pre-groomed, you might feel overwhelmed.  Here's a few things to consider that can help!
 
-- Clinical data at CHOP: What is where? [https://education.arcus.chop.edu/clinical-data-at-chop/](https://education.arcus.chop.edu/clinical-data-at-chop/)
+- [Clinical data at CHOP: What is where?](https://education.arcus.chop.edu/clinical-data-at-chop/)
 - Data dictionaries and variable names: make sure you watch the SQL training videos in your lab, where we go over the use of `dd_field` and `dd_table`, to help you work with data dictionaries.
 - Errors, outliers, and typos do exist, because people make mistakes in charting, and the medical record system isn't foolproof.  What will you do with unexpected or unlikely data?
-- Repeated versions of a variable [https://education.arcus.chop.edu/date-pairing-in-r/](https://education.arcus.chop.edu/date-pairing-in-r/)
-- Missing values: None, NULL, NaN, etc. may also be a challenge.  Consider [https://education.arcus.chop.edu/do-patterns-in-missing-data-matter/](https://education.arcus.chop.edu/do-patterns-in-missing-data-matter/).
+- Repeated versions of a variable -- Here's [an article that looks at repeated variable versions in R](https://education.arcus.chop.edu/date-pairing-in-r/)
+- Missing values: None, NULL, NaN, etc. may also be a challenge.  Check out this [article on missing data](https://education.arcus.chop.edu/do-patterns-in-missing-data-matter/).
 
 
 ## Framing your questions so the computer will understand
@@ -76,7 +76,7 @@ Sometimes, facing an empty screen without any code yet written can feel like an 
 
 - Breaking ideas down into steps (for example, use pseudocode, a fancy word for "steps written out in fake code" to plan your data selection and data analysis)
 - Finding where to start (what fields already exist in the data vs. what will you need to refine/calculate/reformat)
-- Learning to work with your lab directory structure.  A resource that might help is our short [Directories and File Paths](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md) course or the article [https://education.arcus.chop.edu/file-paths/](https://education.arcus.chop.edu/file-paths/)
+- Learning to work with your lab directory structure.  A resource that might help is our short [Directories and File Paths](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md) course or the article [File Paths for Data Scientists](https://education.arcus.chop.edu/file-paths/)
 - Conventions for naming files.  You want to be on the same page as the rest of the team and watch out for things to avoid (like spaces in file names, which can be annoying in some environments).
 - Translating ideas into questions, and questions into tests: what is your algorithm to get from data to publication?
 

--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -17,6 +17,7 @@ First, some various and sundry things that might interest you, beginning with an
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
 <div class = "cool-fact">
+
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
@@ -24,6 +25,7 @@ If you think you'd like to participate in a research study about the educational
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
+
 </div>
 
 Training Modules:

--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -20,8 +20,8 @@ This grant includes the creation of dozens of modules that are aimed at being 1 
 
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
-* Our interest form at https://redcap.link/dart-interest
-* Taking the screening for participation in the study at https://redcap.link/DART-survey
+* Filling out our [interest form](https://redcap.link/dart-interest)
+* Taking the [screening for participation in the study](https://redcap.link/DART-survey)
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 

--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -16,17 +16,14 @@ First, some various and sundry things that might interest you, beginning with an
 
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
-<div class = "warning">
+<div class = "cool-fact">
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
 * Taking the screening for participation in the study at https://redcap.link/DART-survey
 * Emailing us at dart@chop.edu
 
-and consider **not** consuming these modules.
-
-Consuming these modules will **render you ineligible to participate** in our research.  However, we know that they're useful on their own, outside of our conduct of research, so we're fast-tracking access to these materials.
-
+If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
 </div>
 
 Training Modules:

--- a/new_to_python.md
+++ b/new_to_python.md
@@ -8,7 +8,7 @@ title: Arcus Labs Orientation
 
 **What is Python?**
 
-![](media/jupyterlab.png)<!-- style = "max-width:400px; float:left; margin-right: 2rem; margin-bottom: 2rem;"-->
+![""](media/jupyterlab.png)<!-- style = "max-width:400px; float:left; margin-right: 2rem; margin-bottom: 2rem;"-->
 
 Python is a general purpose programming language that can be used in a number of settings, from website development to robotics.  For our purposes, one common usage of Python is in data analysis and machine learning.  
 
@@ -22,7 +22,7 @@ Like R, Python is free and open source, and promotes research reproducibility.
 
 ## Arcus-Specific Python Training
 
-![](media/training_videos.png)<!--
+![""](media/training_videos.png)<!--
 style = "max-width:400px; float:right; margin-left: 2em;"-->
 
 For an example of how to use Python / JupyterLab in your Arcus lab, start with the training videos on your lab's landing page.

--- a/new_to_python.md
+++ b/new_to_python.md
@@ -49,6 +49,7 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
 <div class = "cool-fact">
+
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
@@ -56,6 +57,7 @@ If you think you'd like to participate in a research study about the educational
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
+
 </div>
 
 Training modules:

--- a/new_to_python.md
+++ b/new_to_python.md
@@ -52,8 +52,8 @@ This grant includes the creation of dozens of modules that are aimed at being 1 
 
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
-* Our interest form at https://redcap.link/dart-interest
-* Taking the screening for participation in the study at https://redcap.link/DART-survey
+* Filling out our [interest form](https://redcap.link/dart-interest)
+* Taking the [screening for participation in the study](https://redcap.link/DART-survey)
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 

--- a/new_to_python.md
+++ b/new_to_python.md
@@ -48,17 +48,14 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
-<div class = "warning">
+<div class = "cool-fact">
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
 * Taking the screening for participation in the study at https://redcap.link/DART-survey
 * Emailing us at dart@chop.edu
 
-and consider **not** consuming these modules.
-
-Consuming these modules will **render you ineligible to participate** in our research.  However, we know that they're useful on their own, outside of our conduct of research, so we're fast-tracking access to these materials.
-
+If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
 </div>
 
 Training modules:

--- a/new_to_r.md
+++ b/new_to_r.md
@@ -68,16 +68,14 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
-<div class = "warning">
+<div class = "cool-fact">
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
 * Taking the screening for participation in the study at https://redcap.link/DART-survey
 * Emailing us at dart@chop.edu
 
-and consider **not** consuming these modules.
-Consuming these modules will **render you ineligible to participate** in our research.  However, we know that they're useful on their own, outside of our conduct of research, so we're fast-tracking access to these materials.
-
+If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
 </div>
 
 Training modules:

--- a/new_to_r.md
+++ b/new_to_r.md
@@ -10,7 +10,7 @@ Title: New to R?
 
 **What is R?  RStudio?**
 
-![](media/rstudio.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
+![""](media/rstudio.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
 
 R is a free, open source language that is specifically focused on statistical data analysis.  It is [increasing in market share among researchers](https://r4stats.com/articles/popularity/) (second only to SPSS and outpacing SAS, Stata, JMP, Matlab, and other solutions you may have used) and has multiple advantages over "point and click" statistical data analysis.
 
@@ -36,19 +36,19 @@ Unless you recently left graduate school, you probably learned a different parad
 
 ## CHOP Has an R User Group!
 
-![](media/chopr_hex.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 200px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
+![""](media/chopr_hex.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 200px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
 
 CHOP has a vibrant R User Group made up of employees from all over the institution who use R for many different use cases.  This is a great place to start connecting with other people, asking for help, and seeking advice.
 
-To join, please visit [https://bit.ly/chopRusers](https://bit.ly/chopRusers)!  This will add you to the Outlook distribution list for emails as well as give you instructions on how to add yourself to our Slack workspace, where people ask coding questions (and answer them!).
+Please fill out this form to [join the CHOPR User Group](https://bit.ly/chopRusers)!  This will add you to the Outlook distribution list for emails as well as give you instructions on how to add yourself to our Slack workspace, where people ask coding questions (and answer them!).
 
-Joining the R User Group means you'll be informed about periodic intro to R workshops, R User Group talks, and other resources you'll find useful.  Especially if you're the only person in your lab who uses R, it can be important to find a community of practice that can help guide you.  Intro to R workshops are given a few times a year and include five hours of hands-on, synchronous work intended to get you started working with R as a brand-new beginner.  To learn more about the course, visit the [course website](https://arcus.github.io/intro-to-r-for-clinicians-chop/).
+Joining the R User Group means you'll be informed about periodic intro to R workshops, R User Group talks, and other resources you'll find useful.  Especially if you're the only person in your lab who uses R, it can be important to find a community of practice that can help guide you.  Intro to R workshops are given a few times a year and include five hours of hands-on, synchronous work intended to get you started working with R as a brand-new beginner.  To learn more about the course, visit the [R101 course website](https://arcus.github.io/intro-to-r-for-clinicians-chop/).
 
 As you gain expertise, we also invite you to participate by leading an R User Group meeting!  You don't have to be an expert for years in order to share your skills.  Even if you only know a little, you know more than some people, and you can share pitfalls to avoid and the routes to success for data analysis tasks you conducted on your type of research data.
 
 ## Arcus-Specific R Training
 
-![](media/training_videos.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
+![""](media/training_videos.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
 
 For an example of how to use R in your Arcus lab, start with the training videos on your lab's landing page.
 
@@ -72,8 +72,8 @@ This grant includes the creation of dozens of modules that are aimed at being 1 
 
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
-* Our interest form at https://redcap.link/dart-interest
-* Taking the screening for participation in the study at https://redcap.link/DART-survey
+* Filling out our [interest form](https://redcap.link/dart-interest)
+* Taking the [screening for participation in the study](https://redcap.link/DART-survey)
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 

--- a/new_to_r.md
+++ b/new_to_r.md
@@ -69,6 +69,7 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
 <div class = "cool-fact">
+
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
@@ -76,6 +77,7 @@ If you think you'd like to participate in a research study about the educational
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
+
 </div>
 
 Training modules:

--- a/new_to_sql.md
+++ b/new_to_sql.md
@@ -39,6 +39,7 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
 <div class = "cool-fact">
+
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
@@ -46,6 +47,7 @@ If you think you'd like to participate in a research study about the educational
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
+
 </div>
 
 Training modules:

--- a/new_to_sql.md
+++ b/new_to_sql.md
@@ -10,7 +10,7 @@ title: New to SQL
 
 **What is SQL? SQLPad?**
 
-![](media/sqlpad.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
+![""](media/sqlpad.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
 
 SQL, or Structured Query Language, is a way to interact with data that is stored in a special kind of storage called a relational database.  This kind of data is stored in tables which have rows and columns.
 
@@ -18,7 +18,7 @@ SQLPad is a software package that allows you to send SQL queries to a connected 
 
 ## Arcus-Specific SQL Training
 
-![](media/training_videos.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
+![""](media/training_videos.png)<!-- style = "border: 1px solid rgb(var(--color-highlight)); max-width: 600px; float: left; margin-right: 2rem; margin-bottom: 2rem;"-->
 
 For an example of how to use SQL data in your Arcus lab, start with the training videos on your lab's landing page.
 
@@ -42,8 +42,8 @@ This grant includes the creation of dozens of modules that are aimed at being 1 
 
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
-* Our interest form at https://redcap.link/dart-interest
-* Taking the screening for participation in the study at https://redcap.link/DART-survey
+* Filling out our [interest form](https://redcap.link/dart-interest)
+* Taking the [screening for participation in the study](https://redcap.link/DART-survey)
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 

--- a/new_to_sql.md
+++ b/new_to_sql.md
@@ -38,17 +38,14 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
-<div class = "warning">
+<div class = "cool-fact">
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
 * Taking the screening for participation in the study at https://redcap.link/DART-survey
 * Emailing us at dart@chop.edu
 
-and consider **not** consuming these modules.
-
-Consuming these modules will **render you ineligible to participate** in our research.  However, we know that they're useful on their own, outside of our conduct of research, so we're fast-tracking access to these materials.
-
+If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
 </div>
 
 Training modules:

--- a/new_to_version_control.md
+++ b/new_to_version_control.md
@@ -25,6 +25,7 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
 <div class = "cool-fact">
+
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
@@ -32,6 +33,7 @@ If you think you'd like to participate in a research study about the educational
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
+
 </div>
 
 Training modules:

--- a/new_to_version_control.md
+++ b/new_to_version_control.md
@@ -28,8 +28,8 @@ This grant includes the creation of dozens of modules that are aimed at being 1 
 
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
-* Our interest form at https://redcap.link/dart-interest
-* Taking the screening for participation in the study at https://redcap.link/DART-survey
+* Filling out our [interest form](https://redcap.link/dart-interest)
+* Taking the [screening for participation in the study](https://redcap.link/DART-survey)
 * Emailing us at dart@chop.edu
 
 If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
@@ -49,9 +49,9 @@ Additionally, beyond the NIH grant, we have other articles and miscellany we sug
 
 **Arcus Articles**:
 
-[https://education.arcus.chop.edu/version-control-curriculum/](https://education.arcus.chop.edu/version-control-curriculum/)
-[https://education.arcus.chop.edu/git-101/](https://education.arcus.chop.edu/git-101/)
-[https://education.arcus.chop.edu/git-102/](https://education.arcus.chop.edu/git-102/)
+[Version Control Curriculum](https://education.arcus.chop.edu/version-control-curriculum/)
+[Git 101: Text-based article about the basics](https://education.arcus.chop.edu/git-101/)
+[Git 102: A step-by-step guide for creating your first repository](https://education.arcus.chop.edu/git-102/)
 
 **External Resources**:
 

--- a/new_to_version_control.md
+++ b/new_to_version_control.md
@@ -24,17 +24,14 @@ If you prefer something a bit more "just in time", however, we suggest some reso
 
 This grant includes the creation of dozens of modules that are aimed at being 1 hour or less in duration and each have a narrow focus and clear learning objectives.  They are asynchronous and you can take them at any time!
 
-<div class = "warning">
+<div class = "cool-fact">
 If you think you'd like to participate in a research study about the educational effectiveness of data science training modules, please reach out to Arcus Education's DART program via:
 
 * Our interest form at https://redcap.link/dart-interest
 * Taking the screening for participation in the study at https://redcap.link/DART-survey
 * Emailing us at dart@chop.edu
 
-and consider **not** consuming these modules.
-
-Consuming these modules will **render you ineligible to participate** in our research.  However, we know that they're useful on their own, outside of our conduct of research, so we're fast-tracking access to these materials.
-
+If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you. 
 </div>
 
 Training modules:


### PR DESCRIPTION
I replaced the warnings in each of the "new to..." files. We've changed the exclusion criteria for the DART research program, so folks who have seen our materials will no longer be ineligible to participate. 
I switched it from a warning box to "cool-fact" (icon is a brain), and removed the "don't look at these modules!" language and replaced with a carrot to encourage interested folks to click the links above ("If you meet our research criteria and decide to enroll as a study participant, you'll receive additional data science learning support, including a customized curriculum of materials and the peership and support of a community of learners like you.")