### PR TITLE
Update omics guide CSS link

### DIFF
--- a/new_to_omics.md
+++ b/new_to_omics.md
@@ -1,5 +1,5 @@
 <!--
-link:  https://chop-dbhi-arcus-education-website-assets.s3.amazonaws.com/css/styles.css
+link:  https://storage.googleapis.com/chop-dbhi-arcus-education-website-assets/css/styles.css
 script: https://kit.fontawesome.com/83b2343bd4.js
 title: Arcus Labs Orientation
 -->


### PR DESCRIPTION
Updated CSS link to point to GCP instead of AWS. 