### PR TITLE
Add sample dart pathways

### DIFF
--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -23,11 +23,127 @@ If you'd like to learn more about DART, fill out our [interest form](https://red
 
 </div>
 
-Training Modules:
+**Training Modules:**
 
-* [Learning How to Learn Data Science](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/learning_to_learn/learning_to_learn.md)
+To get started learning about data science, we recommend starting with these modules: 
+
 * [Reproducibility](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md)
 * [How to Troubleshoot](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/how_to_troubleshoot/how_to_troubleshoot.md)
+* [Learning How to Learn Data Science](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/learning_to_learn/learning_to_learn.md)
+
+<br>
+<details>
+<summary><strong>For a deeper introduction to biomedical data science click to see the full 15 module pathway.</strong></summary>
+<br>
+<hr>
+<br>
+<table>
+<thead>
+<tr>
+<th>Order</th>
+<th>Module</th>
+<th>Description</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md">Reproducibility, Generalizability, and Reuse</a></td>
+<td>This module provides learners with an approachable introduction to the concepts and impact of <strong>research reproducibility</strong>, <strong>generalizability</strong>, and <strong>data reuse</strong>, and how technical approaches can help make these goals more attainable.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>2</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/how_to_troubleshoot/how_to_troubleshoot.md">How to Troubleshoot</a></td>
+<td>Learning to use technical methods like coding and version control in your research inevitably means running into problems.  Learn practical methods for troubleshooting and moving past error codes and other difficulties.</td>
+<td>30 min</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/learning_to_learn/learning_to_learn.md">Learning to Learn Data Science</a></td>
+<td>Discover how learning data science is different than learning other subjects.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>4</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_geospatial_data/demystifying_geospatial_data.md">Demystifying Geospatial Data</a></td>
+<td>This module is a brief introduction to geospatial (location) data.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/omics_orientation/omics_orientation.md">Omics Orientation</a></td>
+<td>This module provides a brief introduction to omics and its associated fields.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>6</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_sql/demystifying_sql.md">Demystifying SQL</a></td>
+<td>SQL is a relational database solution that has been around for decades.  Learn more about this technology at a high level, without having to write code.</td>
+<td>40 min</td>
+</tr>
+<tr>
+<td>7</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_machine_learning/demystifying_machine_learning.md">Demystifying Machine Learning</a></td>
+<td>An approachable and practical introduction to machine learning for biomedical researchers.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>8</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_large_language_models/demystifying_large_language_models.md">Demystifying Large Language Models</a></td>
+<td>Learn about large language models (LLM) like ChatGPT.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>9</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_python/demystifying_python.md">Demystifying Python</a></td>
+<td>This module introduces the Python programming language, explores why Python is useful in research, and describes how to download Python and Jupyter.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>10</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_regular_expressions/demystifying_regular_expressions.md">Demystifying Regular Expressions</a></td>
+<td>Learn about pattern matching using regular expressions, or regex.</td>
+<td>30 min</td>
+</tr>
+<tr>
+<td>11</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/citizen_science/citizen_science.md">Citizen Science</a></td>
+<td>This is an overview of citizen science for biomedical researchers.</td>
+<td>45 min</td>
+</tr>
+<tr>
+<td>12</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_containers/demystifying_containers.md">Demystifying Containers</a></td>
+<td>Containers can be a useful tool for reproducible workflows and collaboration. This module describes what containers are, why a researcher might want to use them, and what your options are for implementation.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>13</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/git_intro/git_intro.md">Intro to Version Control</a></td>
+<td>An introduction to what version control systems do and why you might want to use one.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>14</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md">Directories and File Paths</a></td>
+<td>In this module, learners will explore what a directory is and how to describe the location of a file using its file path.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>15</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_management_basics/data_management_basics.md">Research Data Management Basics</a></td>
+<td>Learn the basics about research data management.</td>
+<td>40 min</td>
+</tr>
+</tbody>
+</table>
+<br>
+<hr>
+<br>
+</details>
+<br>
 
 Additionally, beyond the NIH grant, we have other articles and miscellany we suggest, whether those are resources we've created in Arcus, or things we recommend from the larger data science community.
 

--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -25,7 +25,7 @@ If you'd like to learn more about DART, fill out our [interest form](https://red
 
 **Training Modules:**
 
-To get started learning about data science, we recommend starting with these modules: 
+To begin learning about data science, we recommend starting with these modules: 
 
 * [Reproducibility](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md)
 * [How to Troubleshoot](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/how_to_troubleshoot/how_to_troubleshoot.md)

--- a/new_to_data_science.md
+++ b/new_to_data_science.md
@@ -33,7 +33,7 @@ To begin learning about data science, we recommend starting with these modules:
 
 <br>
 <details>
-<summary><strong>For a deeper introduction to biomedical data science click to see the full 15 module pathway.</strong></summary>
+<summary><strong>For a deeper introduction to biomedical data science, click to see the full 15 module pathway.</strong></summary>
 <br>
 <hr>
 <br>

--- a/new_to_python.md
+++ b/new_to_python.md
@@ -69,7 +69,7 @@ To begin learning Python, we recommend starting with these modules:
 
 <br>
 <details>
-<summary><strong>For a deeper introduction to Data Analysis in Python click to see the full 18 module pathway.</strong></summary>
+<summary><strong>For a deeper introduction to Data Analysis in Python, click to see the full 18 module pathway.</strong></summary>
 <br>
 <hr>
 <br>

--- a/new_to_python.md
+++ b/new_to_python.md
@@ -55,7 +55,9 @@ If you'd like to learn more about DART, fill out our [interest form](https://red
 
 </div>
 
-Training modules:
+**Training modules:**
+
+To begin learning Python, we recommend starting with these modules: 
 
 * [Demystifying Python](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_python/demystifying_python.md)
 * [Python Basics: Functions, Methods, and Variables](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/python_basics_variables_functions_methods/python_basics_variables_functions_methods.md)
@@ -64,6 +66,138 @@ Training modules:
 * [Transform Data with pandas](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/pandas_transform/pandas_transform.md)
 * [Data Visualization in seaborn](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_visualization_in_seaborn/data_visualization_in_seaborn.md)
 
+
+<br>
+<details>
+<summary><strong>For a deeper introduction to Data Analysis in Python click to see the full 18 module pathway.</strong></summary>
+<br>
+<hr>
+<br>
+<table>
+<thead>
+<tr>
+<th>Order</th>
+<th>Module</th>
+<th>Description</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md">Reproducibility, Generalizability, and Reuse</a></td>
+<td>This module provides learners with an approachable introduction to the concepts and impact of <strong>research reproducibility</strong>, <strong>generalizability</strong>, and <strong>data reuse</strong>, and how technical approaches can help make these goals more attainable.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>2</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/how_to_troubleshoot/how_to_troubleshoot.md">How to Troubleshoot</a></td>
+<td>Learning to use technical methods like coding and version control in your research inevitably means running into problems.  Learn practical methods for troubleshooting and moving past error codes and other difficulties.</td>
+<td>30 min</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/learning_to_learn/learning_to_learn.md">Learning to Learn Data Science</a></td>
+<td>Discover how learning data science is different than learning other subjects.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>4</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_python/demystifying_python.md">Demystifying Python</a></td>
+<td>This module introduces the Python programming language, explores why Python is useful in research, and describes how to download Python and Jupyter.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md">Directories and File Paths</a></td>
+<td>In this module, learners will explore what a directory is and how to describe the location of a file using its file path.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>6</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/python_basics_variables_functions_methods/python_basics_variables_functions_methods.md">Python Basics: Functions, Methods, and Variables</a></td>
+<td>Learn the foundations of writing Python code, including the use of functions, methods, and variables.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>7</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/python_basics_lists_dictionaries/python_basics_lists_dictionaries.md">Python Basics: Lists and Dictionaries</a></td>
+<td>Learn about collection objects, specifically lists and dictionaries, in Python.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>8</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/python_basics_loops_conditionals/python_basics_loops_conditionals.md">Python Basics: Loops and Conditionals</a></td>
+<td>Learn how to use loops and conditional statements in Python.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>9</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/python_basics_exercise/python_basics_exercise.md">Python Basics: Exercise</a></td>
+<td>Practice the skills acquired in the Python Basics sequence by working through an exercise.</td>
+<td>30 min</td>
+</tr>
+<tr>
+<td>10</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/pandas_transform/pandas_transform.md">Transform Data with pandas</a></td>
+<td>This is an introduction to transforming data using a Python library named pandas.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>11</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/tidy_data/tidy_data.md">Tidy Data</a></td>
+<td>Tidy is a technical term in data analysis and describes an optimal way for organizing data that will be analyzed computationally.</td>
+<td>45 min</td>
+</tr>
+<tr>
+<td>12</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_visualization_in_open_source_software/data_visualization_in_open_source_software.md">Data Visualization in Open Source Software</a></td>
+<td>Introduction to principles of data vizualization and typical data vizualization workflows using two common open source libraries: ggplot2 and seaborn.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>13</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_visualization_in_seaborn/data_visualization_in_seaborn.md">Data Visualization in seaborn</a></td>
+<td>This module includes code and explanations for several popular data visualizations using python&#39;s seaborn library. It also includes examples of how to modify seaborn plots to customize them for different uses.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>14</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/intro_to_nhst/intro_to_nhst.md">Introduction to Null Hypothesis Significance Testing</a></td>
+<td>This is an introduction to NHST for biomedical researchers.</td>
+<td>40 min</td>
+</tr>
+<tr>
+<td>15</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/statistical_tests/statistical_tests.md">Statistical Tests in Open Source Software</a></td>
+<td>This module provides an overview of the most commonly used kinds of statistical tests and links to code for running many of them in both R and python.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>16</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/python_practice/python_practice.md">Python Practice</a></td>
+<td>Use the basics of Python coding, data transformation, and data visualization to work with real data.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>17</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_machine_learning/demystifying_machine_learning.md">Demystifying Machine Learning</a></td>
+<td>An approachable and practical introduction to machine learning for biomedical researchers.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>18</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bias_variance_tradeoff/bias_variance_tradeoff.md">Understanding the Bias-Variance Tradeoff</a></td>
+<td>The bias-variance tradeoff is a central issue in nearly all machine learning analyses. This module explains what the tradeoff is, why it matters for machine learning, and what you can do to manage it in your own analyses.</td>
+<td>20 min</td>
+</tr>
+</tbody>
+</table>
+<br>
+<hr>
+<br>
+</details>
+<br>
 
 Additionally, beyond the NIH grant, we have other articles and miscellany we suggest, whether those are resources we've created in Arcus, or things we recommend from the larger Python community.
 

--- a/new_to_r.md
+++ b/new_to_r.md
@@ -74,7 +74,9 @@ If you'd like to learn more about DART, fill out our [interest form](https://red
 
 </div>
 
-Training modules:
+**Training modules:**
+
+To begin learning R, we recommend starting with these modules: 
 
 * [R Basics: Introduction](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_introduction/r_basics_introduction.md)
 * [R Basics: Transform Data](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_transform_data/r_basics_transform_data.md)
@@ -83,6 +85,140 @@ Training modules:
 * [Missing Values in R](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_missing_values/r_missing_values.md)
 * [Data Visualization in ggplot2](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_visualization_in_ggplot2/data_visualization_in_ggplot2.md)
 * [Summary Statistics in R](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_summary_stats/r_summary_stats.md)
+
+
+<br>
+<details>
+<summary><strong>For a deeper introduction to Data Analysis in R click to see the full 18 module pathway.</strong></summary>
+<br>
+<hr>
+<br>
+<table>
+<thead>
+<tr>
+<th>Order</th>
+<th>Module</th>
+<th>Description</th>
+<th>Estimated Time</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>1</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/reproducibility/reproducibility.md">Reproducibility, Generalizability, and Reuse</a></td>
+<td>This module provides learners with an approachable introduction to the concepts and impact of <strong>research reproducibility</strong>, <strong>generalizability</strong>, and <strong>data reuse</strong>, and how technical approaches can help make these goals more attainable.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>2</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/how_to_troubleshoot/how_to_troubleshoot.md">How to Troubleshoot</a></td>
+<td>Learning to use technical methods like coding and version control in your research inevitably means running into problems.  Learn practical methods for troubleshooting and moving past error codes and other difficulties.</td>
+<td>30 min</td>
+</tr>
+<tr>
+<td>3</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_introduction/r_basics_introduction.md">R Basics: Introduction</a></td>
+<td>Introduction to R and hands-on first steps for brand new beginners.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>4</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_visualize_data/r_basics_visualize_data.md">R Basics: Visualizing Data With ggplot2</a></td>
+<td>Learn how to visualize data using R&#39;s <code>ggplot2</code> package.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>5</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_transform_data/r_basics_transform_data.md">R Basics: Transforming Data With dplyr</a></td>
+<td>Learn how to transform (or wrangle) data using R&#39;s <code>dplyr</code> package.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>6</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/tidy_data/tidy_data.md">Tidy Data</a></td>
+<td>Tidy is a technical term in data analysis and describes an optimal way for organizing data that will be analyzed computationally.</td>
+<td>45 min</td>
+</tr>
+<tr>
+<td>7</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/directories_and_file_paths/directories_and_file_paths.md">Directories and File Paths</a></td>
+<td>In this module, learners will explore what a directory is and how to describe the location of a file using its file path.</td>
+<td>15 min</td>
+</tr>
+<tr>
+<td>8</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_basics_practice/r_basics_practice.md">R Basics Practice</a></td>
+<td>Use the basics of R coding, data transformation, and data visualization to work with real data.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>9</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_reshape_long_wide/r_reshape_long_wide.md">Reshaping Data in R: Long and Wide Data</a></td>
+<td>A module that teaches how to reshape tabular data in R, concentrating on some typical shapes known as "long" and "wide" data.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>10</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_missing_values/r_missing_values.md">Missing Values in R</a></td>
+<td>A practical demonstration of how missing values show up in R and how to deal with them. Note that this module does <strong>not</strong> cover statistical approaches for handling missing data, but instead focuses on the code you need to find, work with, and assign missing values in R.</td>
+<td>45 min</td>
+</tr>
+<tr>
+<td>11</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_summary_stats/r_summary_stats.md">Summary Statistics in R</a></td>
+<td>Learn to calculate summary statistics in R, and how to present them in a table for publication.</td>
+<td>30 min</td>
+</tr>
+<tr>
+<td>12</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_visualization_in_open_source_software/data_visualization_in_open_source_software.md">Data Visualization in Open Source Software</a></td>
+<td>Introduction to principles of data visualization and typical data visualization workflows using two common open source libraries: ggplot2 and seaborn.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>13</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/data_visualization_in_ggplot2/data_visualization_in_ggplot2.md">Data Visualization in ggplot2</a></td>
+<td>This module includes code and explanations for several popular data visualizations, using R&#39;s ggplot2 package. It also includes examples of how to modify ggplot2 plots to customize them for different uses (e.g. adhering to journal requirements for visualizations).</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>14</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/intro_to_nhst/intro_to_nhst.md">Introduction to Null Hypothesis Significance Testing</a></td>
+<td>This is an introduction to NHST for biomedical researchers.</td>
+<td>40 min</td>
+</tr>
+<tr>
+<td>15</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/statistical_tests/statistical_tests.md">Statistical Tests in Open Source Software</a></td>
+<td>This module provides an overview of the most commonly used kinds of statistical tests and links to code for running many of them in both R and python.</td>
+<td>20 min</td>
+</tr>
+<tr>
+<td>16</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/r_practice/r_practice.md">R Practice</a></td>
+<td>Use the basics of R coding, data transformation, and data visualization to work with real data.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>17</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/demystifying_machine_learning/demystifying_machine_learning.md">Demystifying Machine Learning</a></td>
+<td>An approachable and practical introduction to machine learning for biomedical researchers.</td>
+<td>60 min</td>
+</tr>
+<tr>
+<td>18</td>
+<td><a href="https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/education_modules/main/bias_variance_tradeoff/bias_variance_tradeoff.md">Understanding the Bias-Variance Tradeoff</a></td>
+<td>The bias-variance tradeoff is a central issue in nearly all machine learning analyses. This module explains what the tradeoff is, why it matters for machine learning, and what you can do to manage it in your own analyses.</td>
+<td>20 min</td>
+</tr>
+</tbody>
+</table>
+<br>
+<hr>
+<br>
+</details>
+<br>
+
 
 Additionally, beyond the NIH grant, we have other articles and miscellany we suggest, whether those are resources we've created in Arcus, or things we recommend from the larger R community.
 

--- a/new_to_r.md
+++ b/new_to_r.md
@@ -89,7 +89,7 @@ To begin learning R, we recommend starting with these modules:
 
 <br>
 <details>
-<summary><strong>For a deeper introduction to Data Analysis in R click to see the full 18 module pathway.</strong></summary>
+<summary><strong>For a deeper introduction to Data Analysis in R, click to see the full 18 module pathway.</strong></summary>
 <br>
 <hr>
 <br>


### PR DESCRIPTION
The longer New to Data Science, R, and Python pathways from the DART website are now available by expanding a `<details>` chunk.