### PR TITLE
Add styles.css

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,3 @@
+img {
+    border: 1px solid rgb(var(--color-highlight));
+}


### PR DESCRIPTION
This adds a style sheet for this repo. We can link to multiple css files in a liascript doc, so we can still use the styles from education_modules, but now we have a place to add styles for this content specifically. 

Right now it's just adding a border around each image (helps to make screenshots stick out against the background).