### PR TITLE
Add message to front of templates

### DIFF
--- a/data_contribution_2_data.md
+++ b/data_contribution_2_data.md
@@ -46,6 +46,12 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 # Arcus Project Template Orientation
 
+<div class = "important">
+<b style="color: rgb(var(--color-highlight));">Important note</b><br>
+
+This is the Project Template Orientation for Arcus Labs created before ? 2025. If your lab was created after ??? ??, 2025, go to the new version of this orientation [using this link](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/Arcus_Labs_Orientation/main/project-template-updated.md#1 ).
+</div>
+
 <div class = "overview">
 
 ## Overview
@@ -70,9 +76,7 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 </div>
 
-<div class = "important">
-
-Hi! This document is still under construction and testing. We apologize in advance for any broken links or unclear language. We invite your feedback. Please add a [support ticket](https://support.arcus.chop.edu/servicedesk/customer/portal/6/create/249) or [email Arcus Library Science](mailto:dlarcuslibraryscience@chop.edu) to let us know what we can improve or suggest additional topics.
+<div class = "warning">
 
 Please note that **many of the links here will only work if you're on the CHOP network**.
 

--- a/data_contribution_2_data.md
+++ b/data_contribution_2_data.md
@@ -49,7 +49,7 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>
 
-This is the Project Template Orientation for Arcus Labs created before ? 2025. If your lab was created after ??? ??, 2025, go to the new version of this orientation [using this link](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/Arcus_Labs_Orientation/main/project-template-updated.md#1 ).
+This is the Project Template Orientation for Arcus Labs created before July 31st, 2025. If your lab was created after July 31st, 2025, go to the new version of this orientation [using this link](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/Arcus_Labs_Orientation/main/project-template-updated.md#1 ).
 </div>
 
 <div class = "overview">

--- a/project-template-updated.md
+++ b/project-template-updated.md
@@ -49,7 +49,7 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 <div class = "important">
 <b style="color: rgb(var(--color-highlight));">Important note</b><br>
 
-This is the Project Template Orientation for Arcus Labs created after ? 2025. If your lab was created before ??? ??, 2025, go to the new version of this orientation [using this link](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/Arcus_Labs_Orientation/main/new_data_contribution.md#17).
+This is the Project Template Orientation for Arcus Labs created after July 31st, 2025. If your lab was created before July 31st, 2025, go to the previous version of this orientation [using this link](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/Arcus_Labs_Orientation/data-contribution-2/data_contribution_2_data.md#1).
 </div>
 <div class = "overview">
 

--- a/project-template-updated.md
+++ b/project-template-updated.md
@@ -46,6 +46,11 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 # Arcus Project Template Orientation
 
+<div class = "important">
+<b style="color: rgb(var(--color-highlight));">Important note</b><br>
+
+This is the Project Template Orientation for Arcus Labs created after ? 2025. If your lab was created before ??? ??, 2025, go to the new version of this orientation [using this link](https://liascript.github.io/course/?https://raw.githubusercontent.com/arcus/Arcus_Labs_Orientation/main/new_data_contribution.md#17).
+</div>
 <div class = "overview">
 
 ## Overview
@@ -70,7 +75,7 @@ import: https://raw.githubusercontent.com/arcus/education_modules/main/_module_t
 
 </div>
 
-<div class = "important">
+<div class = "warning">
 
 Please note that **many of the links here will only work if you're on the CHOP network**.
 


### PR DESCRIPTION
The project template used in labs is being updated. This is adding a message to both the older and newer versions of the PT orientations on which to use. I will add dates to the message once we know when everything is implemented, and then we can merge the PR.